### PR TITLE
Fix return for put async

### DIFF
--- a/Blue10SDK/Blue10SDK.csproj
+++ b/Blue10SDK/Blue10SDK.csproj
@@ -4,7 +4,7 @@
     <Title>Blue10SDK</Title>
     <Description>Blue10 .NET CORE SDK</Description>
     <Summary>Blue10 .NET CORE SDK</Summary>
-    <VersionPrefix>0.1.7</VersionPrefix>
+    <VersionPrefix>0.1.8</VersionPrefix>
     <PackageId>Blue10SDK</PackageId>
     <PackageIcon>b10icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/Blue10SDK/Helpers/B10WebApiAdapter.cs
+++ b/Blue10SDK/Helpers/B10WebApiAdapter.cs
@@ -1,16 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using Blue10SDK.Exceptions;
+using Blue10SDK.Json;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Blue10SDK.Exceptions;
-using Blue10SDK.Json;
 
 namespace Blue10SDK
 {
     public class B10WebApiAdapter : IWebApiAdapter
     {
         #region Fields
-        
+
         private IHttpClientFactory mHttpClientFactory;
 
         #endregion
@@ -81,7 +81,7 @@ namespace Blue10SDK
             var fJson = await fResponseHttp.Content.ReadAsStringAsync().ConfigureAwait(false);
             var fResponsObject = JsonSerializer.Deserialize<JsonDataResult<string>>(fJson, DefaultJsonSerializerOptions.Options);
             if (fResponsObject == null) return default;
-            if (fResponsObject.code == 200 || fResponsObject.code == 202) return fResponsObject.data;
+            if (fResponsObject.code == 200 || fResponsObject.code == 202) return fResponsObject.data ?? "Success";
             throw new Blue10ApiException(fResponsObject.message);
         }
 
@@ -96,6 +96,6 @@ namespace Blue10SDK
             throw new Blue10ApiException(fResponsObject.message);
         }
 
-        
+
     }
 }


### PR DESCRIPTION
Api doesnt return a data object for SignInvoice command. The SDK returns a null on success which seems like a fail. Instead return a "Success" string in case response.Data is null