### PR TITLE
Added new value to EAdministrationAction

### DIFF
--- a/Blue10SDK/Helpers/Enums.cs
+++ b/Blue10SDK/Helpers/Enums.cs
@@ -28,7 +28,8 @@ namespace Blue10SDK
     public enum EAdministrationAction
     {
         update_all_master_data,
-        update_vendors
+        update_vendors,
+        update_purchase_orders
     }
 
     [JsonConverter(typeof(JsonStringEnumConverter))]


### PR DESCRIPTION
Missing enum causes failures when the value is present in the Customer's database